### PR TITLE
feat: support tagging recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,14 @@ const MyCustomComponent = () => {
 | initHotjar     | Initialize method          | (hotjarId: number, hotjarVersion: number, hotjarDebug?: boolean, loggerCallback?: console[method]) | (1933331, 6, false, console.info)                                                                      |
 | identifyHotjar | User identify API method   | (userId: string, userInfo: object, loggerCallback?: console[method])        | ('abcde-12345-12345', {name:"Olli",surname:"Parno",address:"Streets of Tomorrow"}, console.log) |
 | stateChange    | Relative path state change | (relativePath: string, loggerCallback?: console[method])                    | ('route/logged-route/user?registered=true')                                                     |
+| tagRecording   | Tag a recording            | (tags: string[], loggerCallback?: console[method])                          | (['tag1', 'tag2'])                                                                              |
 
 - initHotjar()
 
 1. `hotjarId`: Your Hotjar application ID ex.: 1933331
 2. `hotjarVersion`: Hotjar's current version ex.: 6
 3. `hotjarDebug`: Optional Debug Mode to see hotjar logs in console ex.: true
-4. `logCallback`: Optional callback for logging wether Hotjar is ready or not
+4. `logCallback`: Optional callback for logging whether Hotjar is ready or not
 
 ```tsx
 initHotjar: (
@@ -113,7 +114,7 @@ initHotjar: (
 
 1. `userId`: Unique user's identification as string
 2. `userInfo`: User info of key-value pairs (note this must not be so long and deep according to [docs](https://help.hotjar.com/hc/en-us/articles/360033640653-Identify-API-Reference)) (Please note: **The Identify API is only available to Business plan customers.**)
-3. `logCallback`: Optional callback for logging wether Hotjar identified user or not
+3. `logCallback`: Optional callback for logging whether Hotjar identified user or not
 
 ```tsx
 identifyHotjar: (userId: string, userInfo: object, logCallback?: () => void) =>
@@ -123,10 +124,19 @@ identifyHotjar: (userId: string, userInfo: object, logCallback?: () => void) =>
 - stateChange()
 
 1. `relativePath`: A change in a route specially for SPAs usage. [stateChange docs](https://help.hotjar.com/hc/en-us/articles/360034378534)
-2. `logCallback`: Optional callback for logging wether Hotjar stateChange was called or not
+2. `logCallback`: Optional callback for logging whether Hotjar stateChange was called or not
 
 ```tsx
 stateChange: (relativePath: string, logCallback?: () => void) => boolean;
+```
+
+- tagRecording()
+
+1. `tags`: List of strings to associate with a recording that can be used for filtering
+2. `logCallback`: Optional callback for logging whether Hotjar tagRecording was called or not
+
+```tsx
+tagRecording: (tags: string[], logCallback?: () => void) => boolean;
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "predeploy": "cd example && npm install && npm run build",
     "deploy": "gh-pages -d example/build",
     "format": "prettier --write src/**/*.{js,jsx,ts,tsx}",
-    "lint": "eslint --fix src/**/*.{js,jsx,ts,tsx}",
+    "lint": "eslint --fix \"src/**/*.{js,jsx,ts,tsx}\"",
     "release": "standard-version",
     "make-badges": "istanbul-badges-readme"
   },

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -23,6 +23,7 @@ describe('Tests useHotjar', () => {
     expect(result.current.identifyHotjar).toBeTruthy();
     expect(result.current.readyState).toBeTruthy();
     expect(result.current.stateChange).toBeTruthy();
+    expect(result.current.tagRecording).toBeTruthy();
   });
 
   it('should initHotjar', () => {
@@ -92,6 +93,30 @@ describe('Tests useHotjar', () => {
       logCallback
     );
     expect(consoleInfoSpy).toHaveBeenCalledWith('Hotjar stateChanged');
+  });
+
+  it('should tagRecording with list of tags', () => {
+    const { result } = renderHook(() => useHotjar());
+    const tagRecordingSpy = jest.spyOn(result.current, 'tagRecording');
+    const { tagRecording } = result.current;
+
+    tagRecording(['tag1', 'tag2']);
+
+    expect(tagRecordingSpy).toHaveBeenCalledWith(['tag1', 'tag2']);
+  });
+
+  it('should tagRecording with list of tags and ogCallback', () => {
+    const { result } = renderHook(() => useHotjar());
+    const tagRecordingSpy = jest.spyOn(result.current, 'tagRecording');
+    const consoleInfoSpy = jest.spyOn(console, 'info');
+    const { tagRecording } = result.current;
+
+    const logCallback = console.info;
+
+    tagRecording(['tag1', 'tag2'], logCallback);
+
+    expect(tagRecordingSpy).toHaveBeenCalledWith(['tag1', 'tag2'], logCallback);
+    expect(consoleInfoSpy).toHaveBeenCalledWith('Hotjar tagRecording');
   });
 
   it('should identifyHotjar with broken logCallback', () => {
@@ -180,12 +205,26 @@ describe('Tests Hotjar without being loaded into window', () => {
     );
   });
 
-  it('should stateChange with new relative path and throw errros', () => {
+  it('should stateChange with new relative path and throw errors', () => {
     const { result } = renderHook(() => useHotjar());
     const { stateChange } = result.current;
     const consoleErrorSpy = jest.spyOn(console, 'error');
 
     stateChange('new/relative/path');
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      `Hotjar error: ${
+        Error('Hotjar is not available! Is Hotjar initialized?').message
+      }`
+    );
+  });
+
+  it('should tagRecording with new relative path and throw errors', () => {
+    const { result } = renderHook(() => useHotjar());
+    const { tagRecording } = result.current;
+    const consoleErrorSpy = jest.spyOn(console, 'error');
+
+    tagRecording(['tag1', 'tag2']);
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       `Hotjar error: ${

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -72,6 +72,18 @@ export function hotjarIdentifyScript(
   throw Error('Hotjar is not available! Is Hotjar initialized?');
 }
 
+export function hotjarTagRecordingScript(tags: string[]): void {
+  const hasWindow = typeof window !== 'undefined';
+  if (hasWindow && (window as unknown as IWindowHotjarEmbedded).hj) {
+    return (window as unknown as IWindowHotjarEmbedded).hj(
+      'tagRecording',
+      tags
+    );
+  }
+
+  throw Error('Hotjar is not available! Is Hotjar initialized?');
+}
+
 export function checkReadyState(): boolean {
   const hasWindow = typeof window !== 'undefined';
   if (hasWindow && (window as unknown as IWindowHotjarEmbedded).hj) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   hotjarIdentifyScript,
   hotjarInitScript,
   hotjarStateChangeScript,
+  hotjarTagRecordingScript,
 } from './dependencies';
 import { IUseHotjar, TUserInfo } from './types';
 
@@ -78,8 +79,32 @@ export default function useHotjar(): IUseHotjar {
     []
   );
 
+  const tagRecording = React.useCallback(
+    (tags: string[], logCallback?: (...data: unknown[]) => void) => {
+      try {
+        hotjarTagRecordingScript(tags);
+
+        if (logCallback && typeof logCallback === 'function')
+          logCallback(`Hotjar tagRecording`);
+
+        return true;
+      } catch (error) {
+        console.error(`Hotjar error: ${error.message}`);
+
+        return false;
+      }
+    },
+    []
+  );
+
   return React.useMemo(
-    () => ({ readyState, stateChange, initHotjar, identifyHotjar }),
-    [readyState, stateChange, initHotjar, identifyHotjar]
+    () => ({
+      readyState,
+      stateChange,
+      tagRecording,
+      initHotjar,
+      identifyHotjar,
+    }),
+    [readyState, stateChange, tagRecording, initHotjar, identifyHotjar]
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,10 @@ export interface IUseHotjar {
     relativePath: string,
     logCallback?: ((...data: unknown[]) => void) | undefined
   ) => boolean;
+  tagRecording: (
+    tags: string[],
+    logCallback?: (...data: unknown[]) => void
+  ) => boolean;
 }
 
 export interface IWindowHotjarEmbedded extends Window {


### PR DESCRIPTION
Hello,

I am submitting a PR to support a wrapper for [tagging Hotjar recordings](https://help.hotjar.com/hc/en-us/articles/115011819488-How-to-Tag-your-Hotjar-Recordings#auto) so my team can use this in a project.
```
hj('tagRecording', ['tag1', 'tag2']);
```

I am unfamiliar with contributing to open-source projects so please let me know if I am missing anything.
Thanks!